### PR TITLE
add obj writer

### DIFF
--- a/jigsawpy/__init__.py
+++ b/jigsawpy/__init__.py
@@ -87,6 +87,7 @@ from jigsawpy.tools.mathutils import R3toS2, S2toR3
 
 from jigsawpy.tools.meshutils import attach, jumble
 
+from jigsawpy.parse.saveobj import saveobj
 from jigsawpy.parse.saveoff import saveoff
 from jigsawpy.parse.savewav import savewav
 from jigsawpy.parse.savevtk import savevtk

--- a/jigsawpy/parse/saveobj.py
+++ b/jigsawpy/parse/saveobj.py
@@ -1,0 +1,118 @@
+
+import warnings
+from pathlib import Path
+
+from jigsawpy.msh_t import jigsaw_msh_t
+from jigsawpy.certify import certify
+
+
+def savepoint(data, fptr, ndim):
+    """
+    SAVEPOINT: save the POINT data structure to *.obj file.
+
+    """
+    rmax = 2 ** 19; next = 0
+
+    while (next < data.shape[0]):
+
+        nrow = min(rmax, data.shape[0] - next)
+        nend = next + nrow
+
+        sfmt = "v " + " ".join(["%.17g"] * ndim)
+        if (ndim < 3): sfmt = sfmt + " 0"
+
+        sfmt = sfmt + "\n"
+        sfmt = sfmt * nrow
+
+        fdat = sfmt % tuple(data[next:nend, :].ravel())
+
+        fptr.write(fdat)
+
+        next = next + nrow
+
+
+def savecells(data, fptr, nnod):
+    """
+    SAVECELLS: save the CELLS data structure to *.obj file.
+
+    """
+    rmax = 2 ** 19; next = 0
+
+    while (next < data.shape[0]):
+
+        nrow = min(rmax, data.shape[0] - next)
+        nend = next + nrow
+
+        sfmt = " ".join(["%d"] * nnod) + "\n"
+        sfmt = "f " + sfmt
+        sfmt = sfmt * nrow
+
+        c = data[next:nend,:] + 1
+        fdat = sfmt % tuple(c.ravel())
+
+        fptr.write(fdat)
+
+        next = next + nrow
+
+
+def save_mesh_file(mesh, fptr):
+    """
+    SAVE-MESH-FILE: save a JIGSAW mesh object to *.obj file.
+
+    """
+    fptr.write(
+        "# " + Path(fptr.name).name +
+        "; created by JIGSAW's Python interface \n")
+
+    if (mesh.vert3 is not None):
+        savepoint(
+            mesh.vert3["coord"], fptr, +3)
+
+    if (mesh.tria3 is not None):
+        savecells(
+            mesh.tria3["index"], fptr, +3)
+
+
+def saveobj(name, mesh):
+    """
+    SAVEOBJ: save a JIGSAW MSH object to file.
+
+    SAVEOBJ(NAME, MESH)
+
+    MESH is JIGSAW's primary mesh/grid/geom class. See MSH_t
+    for details.
+
+    Data in MESH is written as-needed -- any objects defined
+    will be saved to file.
+
+    """
+
+    if (not isinstance(name, str)):
+        raise TypeError("Incorrect type: NAME.")
+
+    if (not isinstance(mesh, jigsaw_msh_t)):
+        raise TypeError("Incorrect type: MESH.")
+
+    certify(mesh)
+
+    fext = Path(name).suffix
+
+    if (fext.strip() != ".obj"): name += ".obj"
+
+    kind = mesh.mshID.lower()
+
+    with Path(name).open("w") as fptr:
+    #----------------------------------- write JIGSAW object
+        if   (kind == "euclidean-mesh"):
+
+            save_mesh_file(mesh, fptr)
+
+        elif (kind == "ellipsoid-mesh"):
+
+            save_mesh_file(mesh, fptr)
+
+        else:
+            raise ValueError(
+                "MESH.mshID is not supported!!")
+
+    return

--- a/tests/case_6_.py
+++ b/tests/case_6_.py
@@ -70,4 +70,9 @@ def case_6_(src_path, dst_path):
     jigsawpy.savevtk(os.path.join(
         dst_path, "case_6c.vtk"), mesh)
 
+    print("Saving case_6c.obj file.")
+
+    jigsawpy.saveobj(os.path.join(
+        dst_path, "case_6c.obj"), mesh)
+
     return

--- a/tests/case_7_.py
+++ b/tests/case_7_.py
@@ -48,4 +48,8 @@ def case_7_(src_path, dst_path):
     jigsawpy.savevtk(os.path.join(
         dst_path, "case_7b.vtk"), mesh)
 
+    print("Saving case_7b.obj file.")
+    jigsawpy.saveobj(os.path.join(
+        dst_path, "case_7b.obj"), mesh)
+
     return


### PR DESCRIPTION
### Summary

This PR adds the ability to write the jigsaw mesh data structure as a [Wavefront .obj](https://en.wikipedia.org/wiki/Wavefront_.obj) file file. Currently, only the 3d point coordinates and triangles are written - future work could include writing more general polygons.

### Testing

Tested by writing some obj files in test cases 6 and 7. Still need to determine if the triangles are written with the correct orientation - the lighting model used below indicates some normals may be pointing outwards from the surface, and some are pointing inwards.

<img width="400" alt="wheel" src="https://github.com/dengwirda/jigsaw-python/assets/15183590/f3b316b7-2591-43cd-9840-9421c627a129">
